### PR TITLE
correct variable name and parallel

### DIFF
--- a/1_generate_consensus_sequences.sh
+++ b/1_generate_consensus_sequences.sh
@@ -188,7 +188,7 @@ do
 		
 		
 			makecons () {
-				local run=$1
+				local CONTIG=$1
 				FILE=${CONTIG/*\/*contigs\//}
 				GENE=${FILE/.fasta/}
 				
@@ -239,9 +239,14 @@ do
 			}
 		
 		
-		for CONTIG in $CONTIGPATH/*.fasta; do 
+		max_jobs="$THREADS"
+		current_jobs=0
+		for CONTIG in $CONTIGPATH/*.fasta; do
+				((current_jobs >= max_jobs)) && wait -n 
 				makecons "$CONTIG" & 
+				((++current_jobs))
 		done
+		wait
 				
 		DURATION_SAMPLE=$SECONDS
 		echo -e '\e[1A\e[K'Generated consensus for $SAMPLE in $(($DURATION_SAMPLE / 60)) minutes and $(($DURATION_SAMPLE % 60)) seconds.


### PR DESCRIPTION
The locally defined variable "run" is not used again, so I assume it was a typo. I changed it to what made sense to me (i.e., you want the CONTIG variable to be local to each call of the function).

The loop putting jobs in the background for each contig will end up assigning up to, e.g., 300+ jobs at a time (beyond threads available). I added a bit to make sure no more than THREADS jobs are running at a time. There is still the potentially undesirable behaviour that each job itself asks for THREADS for bwa, but given the mapping is super fast, this may not be a problem.

The loop also would finish for each sample and move on to the next before the background jobs were finished, so I added a "wait" after the loop to avoid this.