### PR TITLE
set threshold_value for case with file

### DIFF
--- a/1b_assess_dataset.R
+++ b/1b_assess_dataset.R
@@ -218,6 +218,7 @@ if (length(remove_loci_for_all_samples_with_more_than_this_mean_proportion_of_SN
   if(file.exists(file_with_putative_paralogs_to_remove_for_all_samples) == FALSE){
     print("File with list of paralogs to remove for all samples does not exist.")
   } else {
+    threshold_value <- 1
     outloci_para_all <- readLines(file_with_putative_paralogs_to_remove_for_all_samples)
     outloci_para_all_values <-loci_cl1_colmeans[which(names(loci_cl1_colmeans) %in% outloci_para_all)]
   }


### PR DESCRIPTION
In the case that the user specifies a file of paralogs to be removed from every sample, the script will hit an error when checking the value of "threshold_value" (line 251), since it has not been defined.
I have added a meaningless value for "threshold_value" at the point where the script checks whether a file has been specified for the paralog removal steps.