### PR TITLE
added definitions for variables expected in environment

### DIFF
--- a/1c_generate_sequence_lists.R
+++ b/1c_generate_sequence_lists.R
@@ -39,6 +39,11 @@ outloci_para_all <- readRDS(file=file.path(output_Robjects,"outloci_para_all.Rds
 outloci_para_each <- readRDS(file=file.path(output_Robjects,"outloci_para_each.Rds"))
 tab_snps_cl2b <- readRDS(file=file.path(output_Robjects,"Table_SNPs_cleaned.Rds"))
 
+tab_snps <- as.matrix(tab_snps_cl2b)
+loci <- t(tab_snps)
+failed_loci <- which(colSums(is.na(loci))==nrow(loci))
+failed_samples <- which(colSums(is.na(tab_snps))==nrow(tab_snps))
+
 
 #############################################
 


### PR DESCRIPTION
I have added definitions for variables expected to be in the R environment so that this script can be run independently of the previous script.
I assume the variables "failed_loci" and "failed_samples" are calculated correctly here, but I am using the cleaned SNPs table rather than the raw one as in the previous script. I hope that is OK.

This addresses issue #6 