### PR TITLE
allow different locus naming convention

### DIFF
--- a/1a_count_snps.R
+++ b/1a_count_snps.R
@@ -75,8 +75,8 @@ for(sample in samples){
     } else {
       stats <- c(NA,NA)
     }  
-    tab_sample$seq_length[grep(gene,tab_sample$targets)] <- stats[1]
-    tab_sample$ambis[grep(gene,tab_sample$targets)] <- stats[2]  
+    tab_sample$seq_length[match(gene,tab_sample$targets)] <- stats[1]
+    tab_sample$ambis[match(gene,tab_sample$targets)] <- stats[2]  
   
   }
   


### PR DESCRIPTION
This adds functionality to the script for working on data that is not output from HybPiper and names its loci differently (e.g. 0–352).

In order to avoid multiple matches with `grep` (e.g. locus "12" matches "12", "112", "212"), I've changed to `match` so that only a single locus is matched. This should not change the way the function works on HybPiper data.