### PR TITLE
Fix 2_extract_mapped_reads.sh

### DIFF
--- a/2_extract_mapped_reads.sh
+++ b/2_extract_mapped_reads.sh
@@ -123,6 +123,7 @@ do
 		rm $OUTDIR/$SAMPLE"_mapped_reads.fasta" 2>/dev/null
 		
 	else
+		echo Keeping all reads for $SAMPLE
 		# NOTE: if the following commented code is run on paired-end interleaved data,
 		#		which is the normal output from HybPhaser, one of the paired reads
 		#		will be dropped (they have identical names), which seems like non-ideal


### PR DESCRIPTION
This patch fixes two main issues with the `2_extract_mapped_reads.sh` script:

1) The namelist argument and file was not being used to select which samples to run on because the block that processes the samples runs on every subfolder regardless of that argument. The block now correctly runs on the sample list (which varies if there is a namelist argument). Additionally, the list of samples generated when there is no namelist now should work, whereas it used to do nothing (the variables it defined were never referenced again) and set a "SAMPLE" variable to the first sample only.

2) The implementation of Pierre's solution was not actually what Pierre had posted (had syntax errors), but it should now work as intended for the deduplication. In addition, the original script was running a dereplication step when deduplication was false (the default), but if that is run on paired-end read files that are interleaved, then one of the mates is dropped, which doesn't seem to fit the intention (unless I'm missing something). I added a comment directly in that spot and commented out the code.