### PR TITLE
Unique locus search

### DIFF
--- a/1c_generate_sequence_lists.R
+++ b/1c_generate_sequence_lists.R
@@ -123,7 +123,7 @@ if(Sys.info()['sysname']=="Linux"){
   } else {
     for(locus in targets_name){
       #list all fasta files from that locus for all samples
-      fasta_files <- list.files(path=file.path(path_to_output_folder,"01_data/"), pattern=paste(locus,".fasta",sep=""), recursive=TRUE, full.names = TRUE)
+      fasta_files <- list.files(path=file.path(path_to_output_folder,"01_data/"), pattern=paste("^",locus,".fasta",sep=""), recursive=TRUE, full.names = TRUE)
       #select consensus/contig files
       consensus_files <- grep("consensus",fasta_files,value = TRUE)
       contigs_files <- grep("contigs",fasta_files,value = TRUE)

--- a/1c_generate_sequence_lists.R
+++ b/1c_generate_sequence_lists.R
@@ -100,7 +100,7 @@ if(Sys.info()['sysname']=="Linux"){
   if(intronerated_contig=="yes"){
     for(locus in targets_name){
       #list all fasta files from that locus for all samples
-      fasta_files <- list.files(path=file.path(path_to_output_folder,"01_data/"), pattern=paste(locus,"_intronerated.fasta",sep=""), recursive=TRUE, full.names = TRUE)
+      fasta_files <- list.files(path=file.path(path_to_output_folder,"01_data/"), pattern=paste("^",locus,"_intronerated.fasta",sep=""), recursive=TRUE, full.names = TRUE)
       #select consensus/contig files
       consensus_files <- grep("consensus",fasta_files,value = TRUE)
       contigs_files <- grep("contigs",fasta_files,value = TRUE)


### PR DESCRIPTION
This is just a minor change to ensure that unconventional locus names are matched exactly. Without the modification, if a locus name was equal to the end of another locus name, it would hit twice.