### PR TITLE
Correct file list from directory search

### DIFF
--- a/2a_prepare_bbsplit_script.R
+++ b/2a_prepare_bbsplit_script.R
@@ -3,99 +3,99 @@
 ###########################################################
 
 # load config
-if (!(exists("config_file"))) {config_file <- "./config.txt"}
+if (!(exists("config_file"))) {
+	config_file <- "./config.txt"
+}
 source(config_file)
 
 
-if(read_type_cladeassociation == "paired-end"){
-  
-  read_files <- list.files(path_to_read_files_cladeassociation, full.names = F, pattern = paste("*",ID_read_pair1,".*", sep="") , include.dirs = F)  
-
-} else if(read_type_cladeassociation == "single-end") {
-
-  read_files <- list.files(path_to_read_files_cladeassociation, full.names = F, pattern = "*.*", include.dirs = F)  
-  ID_read_pair1 <- ""
-   
-} else { 
-  
-  print("ERROR READ TYPE NOT SELECTED")
-
+if (read_type_cladeassociation == "paired-end") {
+	read_files <- list.files(path_to_read_files_cladeassociation, full.names = FALSE,
+		pattern = paste0("*", ID_read_pair1, ".*"), include.dirs = FALSE)
+} else if (read_type_cladeassociation == "single-end") {
+	read_files <- list.files(path_to_read_files_cladeassociation, full.names = FALSE,
+		pattern = "*.*", include.dirs = FALSE)
+  	ID_read_pair1 <- ""
+} else {
+	stop(print("ERROR: READ TYPE NOT SELECTED"), call. = FALSE)
 }
 
-if(file_with_samples_included == "" | file_with_samples_included == "none" ){
-   } else {
-  samples_in <- readLines(file_with_samples_included)
-  samples_in <- gsub("\\s*$","",samples_in)
-  read_files_noID <- gsub(ID_read_pair1,"",read_files)
-  read_files_noend <- gsub("[.]fast.*","",read_files_noID)
-  read_files <- read_files[match(samples_in, read_files_noend)]
+if (file_with_samples_included != "" && file_with_samples_included != "none") {
+	samples_in <- readLines(file_with_samples_included)
+	samples_in <- gsub("\\s*$", "", samples_in)
+	read_files_noID <- gsub(ID_read_pair1, "", read_files)
+	read_files_noend <- gsub("[.]fast.*", "", read_files_noID)
+	read_files <- read_files[match(samples_in, read_files_noend)]
 }
 
 
 read_files <- na.exclude(read_files)
 
-folder_bbsplit_stats <- file.path(path_to_clade_association_folder,"bbsplit_stats/")
+folder_bbsplit_stats <- file.path(path_to_clade_association_folder, "bbsplit_stats/")
 dir.create(folder_bbsplit_stats, showWarnings = FALSE)
 
 sample_sequences <- list.files(path_to_reference_sequences)
 
-ref_samples <- read.csv(csv_file_with_clade_reference_names, header = T)
+ref_samples <- read.csv(csv_file_with_clade_reference_names, header = TRUE)
 colnames(ref_samples)[1] <- "samples"
 colnames(ref_samples)[2] <- "abb"
 
-ref_samples_files <- sample_sequences[match(ref_samples$samples,gsub("(_intronerated|_consensus|_contig).*","",sample_sequences))]
+ref_samples_files <- sample_sequences[match(ref_samples$samples,
+	gsub("(_intronerated|_consensus|_contig).*", "", sample_sequences))]
 
-if(length(ref_samples$abb)>0){
-  ref_command <- paste(paste("ref_",ref_samples[,2],"=", path_to_reference_sequences,"/",ref_samples_files, sep=""), collapse=" ")
+if (length(ref_samples$abb) > 0) {
+	ref_command <- paste(paste0("ref_", ref_samples[, 2], "=", path_to_reference_sequences, "/", ref_samples_files),
+		collapse = " ")
 } else {
-  ref_command <- paste("ref=",paste(path_to_reference_sequences,ref_samples_files, collapse = ",",sep=""),sep="")
+	ref_command <- paste("ref=", paste0(path_to_reference_sequences, ref_samples_files, collapse = ","))
 }
 
 
 # setting no of threads
-if(no_of_threads_clade_association == 0 ||  no_of_threads_clade_association == "auto") {
-  threadtext <- ""
+if (no_of_threads_clade_association == 0 || no_of_threads_clade_association == "auto") {
+	threadtext <- ""
 } else {
-  threadtext <- paste(" threads=",no_of_threads_clade_association,sep="")
+	threadtext <- paste0(" threads=", no_of_threads_clade_association)
 }
 
 
-# setting Java memory usage 
-
-if(java_memory_usage_clade_association != ""){
-  caXmx <- paste(" -Xmx",java_memory_usage_clade_association, sep="")
+# setting Java memory usage
+if (java_memory_usage_clade_association != "") {
+	caXmx <- paste0(" -Xmx", java_memory_usage_clade_association)
 } else {
-  caXmx <- ""
+	caXmx <- ""
 }
 
-if(path_to_bbmap == ""){
-  bbsplit_sh <- "bbsplit.sh"
+if (path_to_bbmap == "") {
+	bbsplit_sh <- "bbsplit.sh"
 } else {
-  bbsplit_sh <- file.path(path_to_bbmap,"bbsplit.sh")
+	bbsplit_sh <- file.path(path_to_bbmap, "bbsplit.sh")
 }
 
 
 
-write("#!/bin/bash",file=file.path(path_to_clade_association_folder,"run_bbsplit4clade_association.sh"), append=F)
-  
-for(i in 1:length(read_files)){
-    
-    if(read_type_cladeassociation == "paired-end"){
-      
-      bbsplit_command <- paste(bbsplit_sh," ",ref_command, " in=",file.path(path_to_read_files_cladeassociation,read_files[i]), " in2=",sub(ID_read_pair1,ID_read_pair2,file.path(path_to_read_files_cladeassociation,read_files[i])),threadtext," ambiguous=random ambiguous2=all refstats=",folder_bbsplit_stats, gsub(ID_read_pair1,"",read_files[i]),"_bbsplit-stats.txt", caXmx, sep="")
-      
-    } else {
-  
-      bbsplit_command <- paste(bbsplit_sh," ",ref_command, " in=",file.path(path_to_read_files_cladeassociation,read_files[i]),threadtext," ambiguous=random ambiguous2=all refstats=",folder_bbsplit_stats,read_files[i],"_bbsplit-stats.txt", caXmx, sep="")
-      
-    }
-  
-    write(bbsplit_command,file=file.path(path_to_clade_association_folder,"run_bbsplit4clade_association.sh"), append=T)
-  
-}
-  
-system(command = paste("chmod +x",file.path(path_to_clade_association_folder,"run_bbsplit4clade_association.sh")))
+write("#!/bin/bash", file = file.path(path_to_clade_association_folder, "run_bbsplit4clade_association.sh"),
+	append = FALSE)
 
-if(run_clade_association_mapping_in_R=="yes"){
-  system(command = file.path(path_to_clade_association_folder,"run_bbsplit4clade_association.sh"))
+for (i in seq_len(length(read_files))) {
+	if (read_type_cladeassociation == "paired-end") {
+		bbsplit_command <- paste0(bbsplit_sh, " ", ref_command, " in=",
+			file.path(path_to_read_files_cladeassociation, read_files[i]), " in2=",
+			sub(ID_read_pair1, ID_read_pair2, file.path(path_to_read_files_cladeassociation, read_files[i])),
+			threadtext, " ambiguous=random ambiguous2=all refstats=", folder_bbsplit_stats,
+			gsub(ID_read_pair1, "", read_files[i]), "_bbsplit-stats.txt", caXmx)
+	} else {
+		bbsplit_command <- paste0(bbsplit_sh, " ", ref_command, " in=",
+			file.path(path_to_read_files_cladeassociation, read_files[i]), threadtext,
+			" ambiguous=random ambiguous2=all refstats=", folder_bbsplit_stats, read_files[i],
+			"_bbsplit-stats.txt", caXmx)
+	}
+	write(bbsplit_command, file = file.path(path_to_clade_association_folder, "run_bbsplit4clade_association.sh"),
+		append = TRUE)
+}
+
+system(command = paste("chmod +x", file.path(path_to_clade_association_folder, "run_bbsplit4clade_association.sh")))
+
+if (run_clade_association_mapping_in_R == "yes") {
+	system(command = file.path(path_to_clade_association_folder, "run_bbsplit4clade_association.sh"))
 }

--- a/2b_collate_bbsplit_results.R
+++ b/2b_collate_bbsplit_results.R
@@ -3,23 +3,26 @@
 ##############################################################
 
 # load config
-if (!(exists("config_file"))) {config_file <- "./config.txt"}
+if (!(exists("config_file"))) {
+	config_file <- "./config.txt"
+}
 source(config_file)
 
-# get names of stats files and from it get the name of samples 
-folder_bbsplit_stats <- file.path(path_to_clade_association_folder,"bbsplit_stats")
+# get names of stats files and from it get the name of samples
+folder_bbsplit_stats <- file.path(path_to_clade_association_folder, "bbsplit_stats")
 stats_files <- list.files(folder_bbsplit_stats, "*_bbsplit-stats.txt")
-sample <- gsub("(_mapped.*|.fasta.*|_bbsplit-stats.*)","",stats_files)  # this removes everything after the first . in the name
+# remove everything after the first . in the name
+sample <- gsub("(_mapped.*|.fasta.*|_bbsplit-stats.*)", "", stats_files)
 
-ref_samples <- read.csv(csv_file_with_clade_reference_names, header = T)
+ref_samples <- read.csv(csv_file_with_clade_reference_names, header = TRUE)
 colnames(ref_samples)[1] <- "sample"
 colnames(ref_samples)[2] <- "abbreviation"
 
-#set reference names (full names or abbreviations)
-if("abbreviation" %in% colnames(ref_samples)){
-  ref_names <- ref_samples$abbreviation
+# set reference names (full names or abbreviations)
+if ("abbreviation" %in% colnames(ref_samples)) {
+	ref_names <- ref_samples$abbreviation
 } else {
-  ref_names <- ref_samples$sample
+	ref_names <- ref_samples$sample
 }
 
 
@@ -29,32 +32,34 @@ rownames(tab_clade_assoc) <- ref_names
 colnames(tab_clade_assoc) <- sample
 
 
-for(i in 1:length(stats_files)){
-  #i=1
-  stats_file <- stats_files[i]
-  
-  p_unamb <- read.delim(file.path(folder_bbsplit_stats, stats_file))[,1:2]
-  
-  tab_clade_assoc[,i] <- p_unamb$X.unambiguousReads[match(rownames(tab_clade_assoc), p_unamb$X.name)]
-  
+for (i in seq_len(length(stats_files))) {
+	stats_file <- stats_files[i]
+	p_unamb <- read.delim(file.path(folder_bbsplit_stats, stats_file))[, 1:2]
+	tab_clade_assoc[, i] <- p_unamb$X.unambiguousReads[match(rownames(tab_clade_assoc), p_unamb$X.name)]
 }
 
 
-# The proportions of reads matching unambigously to a reference are sensitive to the genetic distance of references. 
-# E.g. two clade references that are closer related to each other have lower proportions of reads matching to the reference because more reads match ambiguously between those references. 
-# One way to get more comparable data is normalization of proportions, by dividing the proportion of reads matched to a reference by the results from the sample that was used as reference. 
-# This assumes that the reads of the reference sequence matching to the same reference is the maximum possible and therefore set to 1. However, this can deviate due to differnces in sequencing quality, read coverage and other factors. 
+# The proportions of reads matching unambigously to a reference are sensitive to the genetic distance of references.
+# E.g. two clade references that are closer related to each other have lower proportions of reads matching
+# to the reference because more reads match ambiguously between those references.
+# One way to get more comparable data is normalization of proportions, by dividing the proportion of reads matched
+# to a reference by the results from the sample that was used as reference.
+# This assumes that the reads of the reference sequence matching to the same reference is the maximum possible and
+# therefore set to 1.
+# However, this can deviate due to differences in sequencing quality, read coverage and other factors.
 
 
 tab_clade_assoc_norm <- tab_clade_assoc
 
-for(i in 1:length(rownames(tab_clade_assoc))){
-  if(length(grep(paste("\\b",ref_samples$sample[i],"\\b",sep=""),colnames(tab_clade_assoc)))>0){
-    tab_clade_assoc_norm[i,] <- tab_clade_assoc[i,] / tab_clade_assoc[i,grep(paste("\\b",ref_samples$sample[i],"\\b",sep=""),colnames(tab_clade_assoc))]
+for (i in seq_len(length(rownames(tab_clade_assoc)))) {
+	if (length(grep(paste0("\\b", ref_samples$sample[i], "\\b"), colnames(tab_clade_assoc))) > 0) {
+		numerator <- tab_clade_assoc[i, ]
+		denominator <- tab_clade_assoc[i, grep(paste0("\\b", ref_samples$sample[i], "\\b"), colnames(tab_clade_assoc))]
+		tab_clade_assoc_norm[i, ] <- numerator / denominator
   }
 }
 
-match("3",c("1","2","22", "3"))
+match("3", c("1", "2", "22", "3"))
 
 ttab_clade_assoc <- as.data.frame(t(tab_clade_assoc))
 ttab_clade_assoc$sample <- rownames(ttab_clade_assoc)
@@ -64,14 +69,19 @@ ttab_clade_assoc_norm$sample <- rownames(ttab_clade_assoc_norm)
 
 
 # for better assessment, the summary table is added to the clade assessment results
-summary_het_ad_clean <- readRDS(file.path(path_to_output_folder,"00_R_objects", name_for_dataset_optimization_subset, "Summary_table.Rds"))
+summary_het_ad_clean <- readRDS(file.path(path_to_output_folder, "00_R_objects",
+	name_for_dataset_optimization_subset, "Summary_table.Rds"))
 
-tab_hetad_cladeasso <- merge(summary_het_ad_clean,ttab_clade_assoc, by="sample", incomparables = F)
+tab_hetad_cladeasso <- merge(summary_het_ad_clean, ttab_clade_assoc, by = "sample", incomparables = FALSE)
 
-tab_hetad_cladeasso_norm <- merge(summary_het_ad_clean,ttab_clade_assoc_norm, by="sample")
+tab_hetad_cladeasso_norm <- merge(summary_het_ad_clean, ttab_clade_assoc_norm, by = "sample")
 
 # save output
-write.csv(t(tab_clade_assoc), file=file.path(path_to_clade_association_folder,"Table_clade_association.csv"))
-write.csv(t(tab_clade_assoc_norm), file=file.path(path_to_clade_association_folder,"Table_clade_association_normalised.csv"))
-write.csv(tab_hetad_cladeasso, file=file.path(path_to_clade_association_folder,"Table_clade_association_and_summary_table.csv"))
-write.csv(tab_hetad_cladeasso_norm, file=file.path(path_to_clade_association_folder,"Table_clade_association_normalized_and_summary_table.csv"))
+write.csv(t(tab_clade_assoc),
+	file = file.path(path_to_clade_association_folder, "Table_clade_association.csv"))
+write.csv(t(tab_clade_assoc_norm),
+	file = file.path(path_to_clade_association_folder, "Table_clade_association_normalised.csv"))
+write.csv(tab_hetad_cladeasso,
+	file = file.path(path_to_clade_association_folder, "Table_clade_association_and_summary_table.csv"))
+write.csv(tab_hetad_cladeasso_norm,
+	file = file.path(path_to_clade_association_folder, "Table_clade_association_normalized_and_summary_table.csv"))

--- a/3a_prepare_phasing_script.R
+++ b/3a_prepare_phasing_script.R
@@ -3,120 +3,102 @@
 #########################################
 
 # load config
-if (!(exists("config_file"))) {config_file <- "./config.txt"}
+if (!(exists("config_file"))) {
+	config_file <- "./config.txt"
+}
 source(config_file)
 
 
-prep_phasing <- read.csv(csv_file_with_phasing_prep_info, header = T)
+prep_phasing <- read.csv(csv_file_with_phasing_prep_info, header = TRUE)
 prep_phasing[is.na(prep_phasing)] <- ""
 
 path_to_reference_sequences <- file.path(reference_sequence_folder)
 refseqs <- list.files(path_to_reference_sequences)
-refseqs_fullpath <- list.files(path_to_reference_sequences, full.names = T)
-refseqs_samplenames <- gsub("(_intronerated)*_consensus.fasta|(_intronerated)*_contig.fasta","",refseqs)
-reads <- list.files(path_to_read_files_phasing, full.names = T)
+refseqs_fullpath <- list.files(path_to_reference_sequences, full.names = TRUE)
+refseqs_samplenames <- gsub("(_intronerated)*_consensus.fasta|(_intronerated)*_contig.fasta", "", refseqs)
+reads <- list.files(path_to_read_files_phasing, full.names = TRUE)
 
-if(folder_for_phased_reads==""){folder_for_phased_reads <- file.path(path_to_phasing_folder,"phased_reads")}
+if (folder_for_phased_reads == "") {
+	folder_for_phased_reads <- file.path(path_to_phasing_folder, "phased_reads")
+}
 dir.create(folder_for_phased_reads, recursive = TRUE, showWarnings = FALSE)
 
-if(folder_for_phasing_stats==""){folder_for_phasing_stats <- file.path(path_to_phasing_folder,"phasing_stats")}
+if (folder_for_phasing_stats == "") {
+	folder_for_phasing_stats <- file.path(path_to_phasing_folder, "phasing_stats")
+}
 dir.create(folder_for_phasing_stats, recursive = TRUE, showWarnings = FALSE)
 
 
 # prepare reference part of the command
-
-ref_command = vector()
-
-for(i in 1:length(rownames(prep_phasing))){
-  
-  nrefs <- (length(which(prep_phasing[i,] !=""))-1)/2
-  ref_co = vector()
-
-  for(r in 1:nrefs){
-    ref_file <- refseqs_fullpath[match(prep_phasing[i,r*2],refseqs_samplenames)]
-    ref_abb <-prep_phasing[i,r*2+1] 
-    ref_co[r] <- (paste("ref_",ref_abb,"=",ref_file, sep=""))
-  }
-ref_command[i] <- paste(ref_co, collapse = " ")
-}  
-  
+ref_command <- vector()
+for (i in seq_len(length(rownames(prep_phasing)))) {
+	nrefs <- (length(which(prep_phasing[i, ] != "")) - 1) / 2
+	ref_co <- vector()
+	for (r in seq_len(nrefs)) {
+		ref_file <- refseqs_fullpath[match(prep_phasing[i, r * 2], refseqs_samplenames)]
+		ref_abb <- prep_phasing[i, (r * 2) + 1]
+		ref_co[r] <- (paste0("ref_", ref_abb, "=", ref_file))
+	}
+	ref_command[i] <- paste(ref_co, collapse = " ")
+}
 
 
 # setting no of threads
-if(no_of_threads_phasing == 0 ||  no_of_threads_phasing == "auto") {
-  threadtext <- ""
+if (no_of_threads_phasing == 0 || no_of_threads_phasing == "auto") {
+	threadtext <- ""
 } else {
-  threadtext <- paste(" threads=",no_of_threads_phasing,sep="")
+	threadtext <- paste0(" threads=", no_of_threads_phasing)
 }
 
 
-
-# setting Java memory usage 
-
-if(java_memory_usage_phasing != ""){
-  
-  pXmx <- paste(" -Xmx",java_memory_usage_phasing, sep="")
-  
+# setting Java memory usage
+if (java_memory_usage_phasing != "") {
+	pXmx <- paste0(" -Xmx", java_memory_usage_phasing)
 } else {
-  
-  pXmx <- ""
-  
+	pXmx <- ""
 }
 
-if(path_to_bbmap_executables == ""){
-  bbsplit_sh <- "bbsplit.sh"
+if (path_to_bbmap_executables == "") {
+	bbsplit_sh <- "bbsplit.sh"
 } else {
-  bbsplit_sh <- file.path(path_to_bbmap_executables,"bbsplit.sh")
+	bbsplit_sh <- file.path(path_to_bbmap_executables, "bbsplit.sh")
 }
 
 
 # preparing the whole command line
-
 phasing_command <- vector()
-
-if(read_type_4phasing == "paired-end"){
-  
-  for(i in 1:length(rownames(prep_phasing))){
-    
-    read_file_1 <- reads[match(paste(prep_phasing[i,1],ID_read_pair1,sep=""),gsub(".*/","",reads))]
-    read_file_2 <- reads[match(paste(prep_phasing[i,1],ID_read_pair2,sep=""),gsub(".*/","",reads))]
-    
-    phasing_command[i] <- paste(bbsplit_sh," ambiguous=all ambiguous2=all", threadtext," ",ref_command[i], " in=",read_file_1," in2=",read_file_2," basename=",folder_for_phased_reads,"/",prep_phasing[i,1],"_to_%.fastq", " refstats=",folder_for_phasing_stats,"/",prep_phasing[i,1],"_phasing-stats.txt", pXmx, sep="")
-    
-  }  
-
+if (read_type_4phasing == "paired-end") {
+	for (i in seq_len(length(rownames(prep_phasing)))) {
+		read_file_1 <- reads[match(paste0(prep_phasing[i, 1], ID_read_pair1), gsub(".*/", "", reads))]
+		read_file_2 <- reads[match(paste0(prep_phasing[i, 1], ID_read_pair2), gsub(".*/", "", reads))]
+		phasing_command[i] <- paste0(bbsplit_sh, " ambiguous=all ambiguous2=all", threadtext, " ",
+			ref_command[i], " in=", read_file_1, " in2=", read_file_2, " basename=", folder_for_phased_reads,
+			"/", prep_phasing[i, 1], "_to_%.fastq", " refstats=", folder_for_phasing_stats, "/",
+			prep_phasing[i, 1], "_phasing-stats.txt", pXmx)
+	}
 } else if (read_type_4phasing == "single-end") {
-
-  for(i in 1:length(rownames(prep_phasing))){
-    
-    read_file <- reads[grep(paste(prep_phasing[i,1]),reads)]
-    
-    if(length(read_file)>1) { print("ERROR: multiple single end reads are selected!")}
-    
-    phasing_command[i] <- paste(bbsplit_sh," ambiguous=all ambiguous2=all",threadtext," ",ref_command[i], " in=",read_file, " basename=",folder_for_phased_reads,"/",prep_phasing[i,1],"_to_%.fastq", " refstats=",folder_for_phasing_stats,"/",prep_phasing[i,1],"_phasing-stats.txt", pXmx, sep="")
-    
-  }    
-
-} else { 
-  
-  print("ERROR READ TYPE NOT SELECTED")
-  
+	for (i in seq_len(length(rownames(prep_phasing)))) {
+		read_file <- reads[grep(paste(prep_phasing[i, 1]), reads)]
+		if (length(read_file) > 1) {
+			stop(print("ERROR: multiple single end reads are selected!"), call. = FALSE)
+		}
+		phasing_command[i] <- paste0(bbsplit_sh, " ambiguous=all ambiguous2=all", threadtext, " ",
+			ref_command[i], " in=", read_file, " basename=", folder_for_phased_reads, "/",
+			prep_phasing[i, 1], "_to_%.fastq", " refstats=", folder_for_phasing_stats, "/",
+			prep_phasing[i, 1], "_phasing-stats.txt", pXmx)
+	}
+} else {
+	stop(print("ERROR: READ TYPE NOT SELECTED"), call. = FALSE)
 }
 
 
 #### generating phasing bash script
-         
-phasing_script_file <- file.path(path_to_phasing_folder,"run_bbsplit4phasing.sh")           
-write("#!/bin/bash",file=phasing_script_file, append=F)
-write(phasing_command, file=phasing_script_file, append=T)           
-system(command = paste("chmod +x",phasing_script_file))
+phasing_script_file <- file.path(path_to_phasing_folder, "run_bbsplit4phasing.sh")
+write("#!/bin/bash", file = phasing_script_file, append = FALSE)
+write(phasing_command, file = phasing_script_file, append = TRUE)
+system(command = paste("chmod +x", phasing_script_file))
            
 # run in R if selected
-if(run_bash_script_in_R=="yes"){system(command = phasing_script_file)}
-
-           
-           
-        
-
-           
-        
+if (run_bash_script_in_R == "yes") {
+	system(command = phasing_script_file)
+}

--- a/3b_collate_phasing_stats.R
+++ b/3b_collate_phasing_stats.R
@@ -3,45 +3,42 @@
 ###################################
 
 # load config
-if (!(exists("config_file"))) {config_file <- "./config.txt"}
+if (!(exists("config_file"))) {
+	config_file <- "./config.txt"
+}
 source(config_file)
 
 
-phasing_prep <- read.csv(csv_file_with_phasing_prep_info, header=T)
-#as.vector(t(phasing_prep[,1+1:((length(phasing_prep)-1)/2)*2]))
+phasing_prep <- read.csv(csv_file_with_phasing_prep_info, header = TRUE)
 
-if(folder_for_phasing_stats==""){folder_for_phasing_stats <- file.path(path_to_phasing_folder,"phasing_stats/")}
-stats_files <- list.files(folder_for_phasing_stats)
+if (folder_for_phasing_stats == "") {
+	folder_for_phasing_stats <- file.path(path_to_phasing_folder, "phasing_stats/")
+}
+stats_files <- list.files(folder_for_phasing_stats, pattern = "*phasing-stats.txt")
+
 
 # generate empty table (ref_names x samples)
-
-used_reference_abbr <- unique(as.vector(t(phasing_prep[,1+1:((length(phasing_prep)-1)/2)*2])))
-if(length(which(is.na(used_reference_abbr)|used_reference_abbr==""))>0){
-  used_reference_abbr <- used_reference_abbr[-which(is.na(used_reference_abbr)|used_reference_abbr=="")]
+used_reference_abbr <- unique(as.vector(t(phasing_prep[, 1 + 1:((length(phasing_prep) - 1) / 2) * 2])))
+if (length(which(is.na(used_reference_abbr) | used_reference_abbr == "")) > 0) {
+	used_reference_abbr <- used_reference_abbr[- which(is.na(used_reference_abbr) | used_reference_abbr == "")]
 }
 
 
-
 tab_phasing_stats <- matrix(nrow = length(stats_files), ncol = length(used_reference_abbr))
-rownames(tab_phasing_stats) <- gsub("_phasing-stats.txt","",stats_files)
+rownames(tab_phasing_stats) <- gsub("_phasing-stats.txt", "", stats_files)
 colnames(tab_phasing_stats) <- used_reference_abbr
 
 
 # fill table with results from the stats files
-for(i in 1:length(stats_files)){
-  
-  stats_file <- stats_files[i]
-  
-  p_unamb <- read.delim(file.path(folder_for_phasing_stats, stats_file))[,1:2]
-  
-  for(j in 1:length(p_unamb[,1])){
-    tab_phasing_stats[i,match(p_unamb[j,1], colnames(tab_phasing_stats))] <- round(p_unamb[j,2]/100,5)
+for (i in seq_len(length(stats_files))) {
+	stats_file <- stats_files[i]
+	p_unamb <- read.delim(file.path(folder_for_phasing_stats, stats_file))[, 1:2]
+  for (j in seq_len(length(p_unamb[, 1]))) {
+		tab_phasing_stats[i, match(p_unamb[j, 1], colnames(tab_phasing_stats))] <- round(p_unamb[j, 2] / 100, 5)
   }
-
 }
 
 
 # save output
-write.csv(tab_phasing_stats, file=file.path(path_to_phasing_folder,"Table_phasing_stats.csv"), na = "")
-
-
+write.csv(tab_phasing_stats,
+	file = file.path(path_to_phasing_folder, "Table_phasing_stats.csv"), na = "")


### PR DESCRIPTION
The main patch is to add a pattern to the file search in script "3b_collate_phasing_stats.R" (line 17) so that it doesn't just assume all files in the directory are stats files (possible if the user specified a specific directory for the phasing stats rather than a default empty directory).

The other changes are to the 2a 2b 3a 3b scripts to clean up the code a bit for readability and slight syntax changes (these are minor and shouldn't affect the functions).